### PR TITLE
Fix nombre método

### DIFF
--- a/src/Sermepa/Tpv/Tpv.php
+++ b/src/Sermepa/Tpv/Tpv.php
@@ -56,7 +56,7 @@ class Tpv{
      * @param string $value Este parámetro se utilizará para manejar la referencia asociada a los datos de tarjeta. Es un campo alfanumérico de un máximo de 40 posiciones cuyo valor es generado por el TPV Virtual.
      * @throws Exception
      */
-    public function setIdentifier($value='REQUIRED')
+    public function setMerchantIdentifier($value='REQUIRED')
     {
         if(strlen(trim($value)) > 0){
             $this->_setParameters['DS_MERCHANT_IDENTIFIER'] = $value;
@@ -65,6 +65,14 @@ class Tpv{
             throw new Exception('Please add value');
         }
 
+    }
+    
+    /**
+     * @deprecated
+     */
+    public function setIdentifier($value='REQUIRED')
+    {
+        $this->setMerchantIdentifier($value)
     }
 
     public function setMerchantDirectPayment($flat=false)


### PR DESCRIPTION
Cambiar el nombre del método para que este acorde con el naming de la clase y crear workaround para evitar romper la retor compatibilidad.