### PR TITLE
Orden en argumentos predeterminados

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ try{
     $parameters = $redsys->getMerchantParameters($_POST["Ds_MerchantParameters"]);
     $DsResponse = $parameters["Ds_Response"];
     $DsResponse += 0;
-    if ($redsys->check($key, $_POST) && $DsResponse <= 99) {
+    if ($redsys->check($_POST, $key) && $DsResponse <= 99) {
         //acciones a realizar si es correcto, por ejemplo validar una reserva, mandar un mail de OK, guardar en bbdd o contactar con mensajería para preparar un pedido
     } else {
         //acciones a realizar si ha sido erroneo

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ try{
     $parameters = $redsys->getMerchantParameters($_POST["Ds_MerchantParameters"]);
     $DsResponse = $parameters["Ds_Response"];
     $DsResponse += 0;
-    if ($redsys->check($_POST, $key) && $DsResponse <= 99) {
+    if ($redsys->check($key, $_POST) && $DsResponse <= 99) {
         //acciones a realizar si es correcto, por ejemplo validar una reserva, mandar un mail de OK, guardar en bbdd o contactar con mensajería para preparar un pedido
     } else {
         //acciones a realizar si ha sido erroneo

--- a/src/Sermepa/Tpv/Tpv.php
+++ b/src/Sermepa/Tpv/Tpv.php
@@ -739,13 +739,13 @@ class Tpv
     /**
      * Check if properly made ​​the purchase.
      *
-     * @param string $key      Key
      * @param array  $postData Data received by the bank
+     * @param string $key      Key
      *
      * @return bool
      * @throws TpvException
      */
-    public function check($key = '', $postData)
+    public function check($postData, $key = '')
     {
         if (!isset($postData)) {
             throw new TpvException("Add data return of bank");

--- a/src/Sermepa/Tpv/Tpv.php
+++ b/src/Sermepa/Tpv/Tpv.php
@@ -745,9 +745,9 @@ class Tpv
      * @return bool
      * @throws TpvException
      */
-    public function check($postData, $key = '')
+    public function check($key = '', $postData = [])
     {
-        if (!isset($postData)) {
+        if (!isset($postData) || !is_array($postData)) {
             throw new TpvException("Add data return of bank");
         }
 


### PR DESCRIPTION
https://www.php.net/manual/es/functions.arguments.php "Obsérvese que cuando se emplean argumentos predeterminados, cualquiera de ellos debería estar a la derecha de los argumentos no predeterminados; si no, las cosas no funcionarán como se esperaba."

También actualizo README con el ejemplo.

Saludos!