### PR TITLE
refactors to constants and adds tests

### DIFF
--- a/src/Sermepa/Tpv/Tpv.php
+++ b/src/Sermepa/Tpv/Tpv.php
@@ -13,6 +13,15 @@ class Tpv
     CONST READ_TIMEOUT = 120;
     CONST SSLVERSION_TLSv1_2 = 6;
 
+    public const INSTALLMENTS = 'I';
+    public const RECURRING = 'R';
+    public const REAUTHORIZATION = 'H';
+    public const RESUBMISSION = 'E';
+    public const DELAYED = 'D';
+    public const INCREMENTAL = 'M';
+    public const NO_SHOW = 'N';
+    public const OTHER = 'C';
+
     protected $_setEnvironment;
     protected $_setNameForm;
     protected $_setIdForm;
@@ -918,14 +927,32 @@ class Tpv
      */
     public function setMerchantCofType($value)
     {
-        $validOptions = ['I', 'R', 'H', 'E', 'D', 'M', 'N', 'C'];
         $value = strtoupper($value);
-        if (!in_array($value, $validOptions, true)) {
+        if (!self::isValidCofType($value)) {
             throw new TpvException('Set Merchant COF type');
         }
         $this->_setParameters['DS_MERCHANT_COF_TYPE'] = $value;
 
         return $this;
+    }
+
+    private static function isValidCofType($value): bool
+    {
+        return in_array($value, self::getValidCofTypes(), true);
+    }
+
+    private static function getValidCofTypes(): array
+    {
+        return [
+            self::INSTALLMENTS,
+            self::RECURRING,
+            self::REAUTHORIZATION,
+            self::RESUBMISSION,
+            self::DELAYED,
+            self::INCREMENTAL,
+            self::NO_SHOW,
+            self::OTHER,
+        ];
     }
 
     /**

--- a/tests/TpvTest.php
+++ b/tests/TpvTest.php
@@ -539,4 +539,71 @@ class TpvTest extends PHPUnitTestCase
 
      }
 
+    public function validTransactionTypeProvider(): array
+    {
+        return [
+            'Installments' => [Tpv::INSTALLMENTS],
+            'Recurring' => [Tpv::RECURRING],
+            'Reauthorization' => [Tpv::REAUTHORIZATION],
+            'Resubmission' => [Tpv::RESUBMISSION],
+            'Delayed' => [Tpv::DELAYED],
+            'Incremental' => [Tpv::INCREMENTAL],
+            'No Show' => [Tpv::NO_SHOW],
+            'Otras' => [Tpv::OTHER],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider validTransactionTypeProvider
+     */
+    public function transaction_type_is_valid($type): void
+    {
+        $redsys = new Tpv();
+        $redsys->setMerchantCofType($type);
+        $ds = $redsys->getParameters();
+        $this->assertEquals($type, $ds['DS_MERCHANT_COF_TYPE']);
+    }
+
+
+
+    public function invalidTransactionTypeProvider(): array
+    {
+        return [
+            'A' => ['A'],
+            'B' => ['B'],
+            'F' => ['F'],
+            'G' => ['G'],
+            'J' => ['J'],
+            'K' => ['K'],
+            'L' => ['L'],
+            'O' => ['O'],
+            'P' => ['P'],
+            'Q' => ['Q'],
+            'S' => ['S'],
+            'T' => ['T'],
+            'U' => ['U'],
+            'V' => ['V'],
+            'W' => ['W'],
+            'X' => ['X'],
+            'Y' => ['Y'],
+            'Z' => ['Z'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidTransactionTypeProvider
+     */
+
+    public function throw_when_transaction_type_is_not_valid($type): void
+    {
+        $this->expectExceptionMessage('Set Merchant COF type');
+        $this->expectException(\Sermepa\Tpv\TpvException::class);
+        $redsys = new Tpv();
+        $redsys->setMerchantCofType($type);
+
+        $redsys->setParameters($type);
+
+    }
 }


### PR DESCRIPTION
I set string keys to the provider, so it would show the name of the set in the tests instead of `set#2`.

![phpstorm64_cP84AJwImc](https://user-images.githubusercontent.com/6376814/197585481-7ec58c0f-bc8f-4fcb-878f-61573c59266e.png)

Also added constants to be able to set the codes this way:

```php
$redsys->setMerchantCofType(Tpv::RECURRING);
```
