### PR TITLE
Check payments with hash_equals()

### DIFF
--- a/src/Sermepa/Tpv/Tpv.php
+++ b/src/Sermepa/Tpv/Tpv.php
@@ -875,7 +875,7 @@ class Tpv
         $signatureReceived = $postData["Ds_Signature"];
         $signature = $this->generateMerchantSignatureNotification($key, $parameters);
 
-        return ($signature === $signatureReceived);
+        return hash_equals($signature, $signatureReceived);
     }
 
     /**


### PR DESCRIPTION
PHP `hash_equals` should be used instead of `===` to mitigate timing attacks.

PHP docs here: https://www.php.net/manual/en/function.hash-equals.php