### PR TITLE
Let set GooglePay & ApplePay methods

### DIFF
--- a/src/Sermepa/Tpv/Tpv.php
+++ b/src/Sermepa/Tpv/Tpv.php
@@ -628,6 +628,7 @@ class Tpv
      *      z = Bizum
      *      p = PayPal
      *      N = Masterpass
+     *      xpay = GooglePay y ApplePay
      * ]
      *
      * @return $this
@@ -639,7 +640,7 @@ class Tpv
             throw new TpvException('Add pay method');
         }
 
-        if (!in_array($method, ['T', 'C', 'R', 'D', 'z', 'p', 'N'])) {
+        if (!in_array($method, ['T', 'C', 'R', 'D', 'z', 'p', 'N', 'xpay'])) {
             throw new TpvException('Pay method is not valid');
         }
 


### PR DESCRIPTION
If you checkout the Redsys documentation, and you head into [the "DS_MERCHANT_PAYMETHODS" table](https://pagosonline.redsys.es/parametros-entrada-salida.html), you'll be able to see that you can also pay via GooglePay & ApplePay.

I've just updated the code so when calling the `setMethod` function, you can specify to those payments methods:
```php
->setMethod('xpay')
```

![Screenshot 2024-03-05 at 14 53 24](https://github.com/ssheduardo/sermepa/assets/60661635/68c33d56-0260-4db0-a7c6-ca2952dc4da2)

Related documentation:

- https://pagosonline.redsys.es/googlePay.html
- https://pagosonline.redsys.es/applePay.html