### PR TITLE
Fix files not being correctly unzipped

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.github export-ignore
+/.travis.yml export-ignore
+/doc export-ignore
+/tests export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
Hola @ssheduardo,

Este PR arregla un issue durante la instalación del paquete en entornos en los que unzip no acepta acentos en los nombres de fichero.

![Captura de pantalla 2024-03-27 a las 11 30 18](https://github.com/ssheduardo/sermepa/assets/6053012/deb2691b-eea8-4588-bdca-fc61e51d14e3)

Además, reduce el tamaño de la librería ignorando ficheros y carpetas durante la instalación con composer que no se usan en el paquete.

