### PR TITLE
Añadir el tipo de transacción ANULACION_DE_REFERENCIA

### DIFF
--- a/doc/Tabla DS_MERCHANT_TRANSACTIONTYPE.md
+++ b/doc/Tabla DS_MERCHANT_TRANSACTIONTYPE.md
@@ -13,6 +13,7 @@
 | Autenticación Puce                             | 17 | REST/SOAP |
 | Devolución sin original                        | 34 | Redirección <br> REST/SOAP |
 | Premio de apuestas                             | 37 | REST/SOAP |
+| Anulación de referencia                        | 44 | REST/SOAP |
 | Anulación de pago                              | 45 | Redirección <br> REST/SOAP |
 | Anulación de devolución                        | 46 | Redirección <br> REST/SOAP |
 | Anulación de confirmación separada             | 47 | Redirección <br> REST/SOAP |

--- a/src/Redsys/Merchant/MerchantTransactionTypes.php
+++ b/src/Redsys/Merchant/MerchantTransactionTypes.php
@@ -18,6 +18,25 @@
 		public const AUTENTICACION_PUCE                           = 17; // Autenticación Puce
 		public const DEVOLUCION_SIN_ORIGINAL                      = 34; // Devolución sin original
 		public const PREMIO_DE_APUESTAS                           = 37; // Abono de Apuestas
+
+		/**
+		 * Borrar referencia
+		 *
+		 * Si se desea borrar una referencia creada, se debe enviar el parámetro
+		 * Ds_Merchant_Identifier con el valor de la referencia a borrar y el valor
+		 * Ds_Merchant_TransactionType con el valor "44":
+		 * ```json
+		 * {
+		 *   "DS_MERCHANT_MERCHANTCODE": "999008881",
+		 *   "DS_MERCHANT_IDENTIFIER": "a091f0f9f0aaf0506930dda4a6974f1df4a0d9c1",
+		 *   "DS_MERCHANT_ORDER": "0281WjRq",
+		 *   "DS_MERCHANT_TERMINAL": "1",
+		 *   "DS_MERCHANT_TRANSACTIONTYPE": "44"
+		 * }
+		 * ```
+		 */
+		public const ANULACION_DE_REFERENCIA                      = 44; // Anulación de referencia
+
 		public const ANULACION_DE_PAGO                            = 45; // Anulación de pago
 		public const ANULACION_DE_DEVOLUCION                      = 46; // Anulación de devolución
 		public const ANULACION_DE_CONFIRMACION_SEPARADA           = 47; // Anulación de confirmación separada


### PR DESCRIPTION
He añadido el tipo de transacción que elimina una referencia de pago por [tokenización](https://pagosonline.redsys.es/desarrolladores-inicio/documentacion-funcionalidades-avanzadas/tokenizacion/).

Por algún motivo ha desaparecido de la documentación el ejemplo de eliminar un token creado:
```json
{
  "DS_MERCHANT_MERCHANTCODE": "999008881",
  "DS_MERCHANT_IDENTIFIER": "a091f0f9f0aaf0506930dda4a6974f1df4a0d9c1",
  "DS_MERCHANT_ORDER": "0281WjRq",
  "DS_MERCHANT_TERMINAL": "1",
  "DS_MERCHANT_TRANSACTIONTYPE": "44"
}
```

Además he añadido a dicha constante el comentario PHPDoc para que salga la explicación:
![image](https://github.com/user-attachments/assets/9e9f5113-8f48-4a8a-8fd8-b7578b48acea)
La cuestión sería ir añadiendo comentarios PHPDoc ahí donde fuera necesario.